### PR TITLE
Don't give TH100 error when using `cls` rather then `self` in classmethods

### DIFF
--- a/flake8_typehinting/flake8_typehinting.py
+++ b/flake8_typehinting/flake8_typehinting.py
@@ -35,7 +35,7 @@ class Visitor(ast.NodeVisitor):
     def _check_th_100(self, node: ast.FunctionDef) -> None:
         """Check for TH100."""
         for arg in node.args.args:
-            if not arg.arg == 'self' and arg.annotation is None:
+            if not arg.arg in ('self', 'cls') and arg.annotation is None:
                 self.problems.append((node.lineno, node.col_offset, f'{TH100} ({arg.arg})'))
 
     def _check_th_101(self, node: ast.FunctionDef) -> None:


### PR DESCRIPTION
I think that we should also check if the function is inside a class or not, but i don't have any experiense with `ast`.

Fixes: #2 